### PR TITLE
fix(user32): rely on the return value of GetMessage instead of the error return value

### DIFF
--- a/pkg/user32/user32.go
+++ b/pkg/user32/user32.go
@@ -125,23 +125,18 @@ type MinMaxInfo struct {
 	MaxTrackSize Point
 }
 
-// Returns nil on WM_QUIT.
 func GetMessageW() (*Msg, error) {
 	var msg Msg
 
-	r, _, err := getMessageW.Call(
+	r, _, _ := getMessageW.Call(
 		uintptr(unsafe.Pointer(&msg)),
 		0,
 		0,
 		0,
 	)
 
-	if err != nil && !errors.Is(err, errOK) {
-		return nil, err
-	}
-
-	if r == 0 {
-		return nil, nil
+	if int32(r) == -1 {
+		return nil, windows.GetLastError()
 	}
 
 	return &msg, nil

--- a/pkg/webview2/webview.go
+++ b/pkg/webview2/webview.go
@@ -231,7 +231,7 @@ func (wv *WebView) Run() error {
 			return fmt.Errorf("failed to get message: %w", err)
 		}
 
-		if msg == nil || msg.Message == user32.WMQuit {
+		if msg.Message == user32.WMQuit {
 			return nil
 		}
 


### PR DESCRIPTION
Fixes #11